### PR TITLE
delete 'paths-ignore' due to the overlap

### DIFF
--- a/.github/workflows/test-github-workflows.yml
+++ b/.github/workflows/test-github-workflows.yml
@@ -7,9 +7,9 @@ on:
     paths:
       - "dist/**"
 #       - "**.js"
-    # .gitignore과 비슷
-    paths-ignore:
-      - "doc/**"
+    # .gitignore과 비슷 + path와 동시에 사용은 불가능! "!"를 앞에 붙여서 조건문 식츠로 활용해야한다.
+#     paths-ignore:
+#       - "doc/**"
 # jobs:
 #   build:
 #     strategy:


### PR DESCRIPTION
You can not use paths and paths-ignore to filter the same event in a single workflow. If you want to both include and exclude path patterns for a single event, use the paths filter along with the ! character to indicate which paths should be excluded.